### PR TITLE
Add wyoming-piper executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,4 +42,9 @@ setup(
         "Programming Language :: Python :: 3.11",
     ],
     keywords="rhasspy wyoming piper tts",
+    entry_points={
+        'console_scripts': [
+            'wyoming-piper = wyoming_piper:__main__.run'
+        ]
+    },
 )

--- a/wyoming_piper/__main__.py
+++ b/wyoming_piper/__main__.py
@@ -204,8 +204,12 @@ def get_description(voice_info: Dict[str, Any]):
 
 # -----------------------------------------------------------------------------
 
+def run():
+    asyncio.run(main())
+
+
 if __name__ == "__main__":
     try:
-        asyncio.run(main())
+        run()
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
This change provides an executable that will be installed into the bin/ directory of the python environment, which is simpler to start up, because the correct python instance is already implied.