### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.github
+.gitignore
+tests
+.projectile
+pylintrc
+Dockerfile
+*.md
+*.in
+*.ini
+*.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3 AS builder
+
+WORKDIR /src
+
+COPY . .
+
+RUN ./script/setup && ./script/package
+
+FROM python:3
+
+ARG PIPER_VERSION=v1.2.0
+ARG PIPER_ARCH=amd64
+RUN curl -L -s "https://github.com/rhasspy/piper/releases/download/$PIPER_VERSION/piper_$PIPER_ARCH.tar.gz" | tar -zxvf - -C /usr/share
+
+RUN --mount=type=bind,from=builder,target=/mnt/builder pip3 install /mnt/builder/src/dist/*.whl
+
+WORKDIR /src
+COPY docker-entrypoint.sh .
+
+EXPOSE 10300/tcp
+VOLUME /data
+LABEL org.opencontainers.image.source=https://github.com/rhasspy/wyoming-piper
+
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+python3 -m wyoming_piper \
+    --piper '/usr/share/piper/piper' \
+    --uri 'tcp://0.0.0.0:10200' \
+    --data-dir /data \
+    --download-dir /data "$@"


### PR DESCRIPTION
Solves #18.

The image is made to be similar to the one that's published on Docker Hub, but use best practices like a multi-stage build process to make sure the build process is containerized as well.

The Dockerfile would effortlessly support cross-platform builds if the buildx TARGET_ARCH and TARGET_OS could be used. Unfortunately the naming convention of the piper builds are not adhering to the common naming conventions.

Additionally, it would be nice to include a USER clause to make the container work well in a rootless scenario. But I'm not a native to Python and installing the wheel as non-root caused issues.