### PR TITLE
fix - nr of channels not specified before writing wave

### DIFF
--- a/wyoming_piper/handler.py
+++ b/wyoming_piper/handler.py
@@ -230,6 +230,10 @@ class PiperEventHandler(AsyncEventHandler):
                     syn_config.noise_w_scale = self.cli_args.noise_w_scale
 
                 wav_writer: wave.Wave_write = wave.open(output_file, "wb")
+                # Set required WAV parameters before writing
+                wav_writer.setnchannels(1)  # Mono audio
+                wav_writer.setsampwidth(2)  # 16-bit audio (2 bytes)
+                wav_writer.setframerate(16000)  # 16 kHz sample rate
                 with wav_writer:
                     _VOICE.synthesize_wav(text, wav_writer, syn_config)
 


### PR DESCRIPTION
Hey there,
I had an issue that the number of channels was not defined (occasionally?) when using a RPi satellite. This here fixes the issue.

The error I got was:

```
wyoming-piper  | ERROR:asyncio:Task exception was never retrieved
wyoming-piper  | future: <Task finished name='wyoming event handler' coro=<AsyncEventHandler.run() done, defined at /usr/local/lib/python3.10/dist-packages/wyoming/server.py:31> exception=Error('# channels not specified')>
wyoming-piper  | Traceback (most recent call last):
wyoming-piper  |   File "/usr/local/lib/python3.10/dist-packages/wyoming/server.py", line 41, in run
wyoming-piper  |     if not (await self.handle_event(event)):
wyoming-piper  |   File "/usr/local/lib/python3.10/dist-packages/wyoming_piper/handler.py", line 137, in handle_event
wyoming-piper  |     raise err
wyoming-piper  |   File "/usr/local/lib/python3.10/dist-packages/wyoming_piper/handler.py", line 75, in handle_event
wyoming-piper  |     await self._handle_synthesize(
wyoming-piper  |   File "/usr/local/lib/python3.10/dist-packages/wyoming_piper/handler.py", line 233, in _handle_synthesize
wyoming-piper  |     with wav_writer:
wyoming-piper  |   File "/usr/lib/python3.10/wave.py", line 332, in __exit__
wyoming-piper  |     self.close()
wyoming-piper  |   File "/usr/lib/python3.10/wave.py", line 444, in close
wyoming-piper  |     self._ensure_header_written(0)
wyoming-piper  |   File "/usr/lib/python3.10/wave.py", line 462, in _ensure_header_written
wyoming-piper  |     raise Error('# channels not specified')
wyoming-piper  | wave.Error: # channels not specified
```