### PR TITLE
Add default data-dir to docker_run.sh

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 cd /usr/src
 .venv/bin/python3 -m wyoming_piper \
-    --uri 'tcp://0.0.0.0:10200' "$@"
+    --uri 'tcp://0.0.0.0:10200' --data-dir '/data' "$@"


### PR DESCRIPTION
Fixes #38.
Restores compatibility with [README.md#docker-image](https://github.com/danielrheinbay/wyoming-piper/blob/main/README.md#docker-image).
Maintains backwards-compatibility with existing installations using docker-compose.yml. 