### PR TITLE
Fix ignoring SIGTERM from Docker

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 cd /usr/src
-.venv/bin/python3 -m wyoming_piper \
+exec .venv/bin/python3 -m wyoming_piper \
     --uri 'tcp://0.0.0.0:10200' \
     --data-dir /data "$@"


### PR DESCRIPTION
Prior to this commit, when running `docker stop`, docker would send a `SIGTERM` to `docker_run.sh`, but that `SIGTERM` would be blocked by the kernel since `docker_run.sh` runs as PID 1 and it doesn't register its own `SIGTERM` handler. The result was typically that Docker would wait 10s before force killing the container.

With these changes, `docker_run.sh` exec's the Python interpreter so Python becomes PID 1, and `__main__.py` registers a `SIGTERM` (and a `SIGINT`) handler. Stopping the container should now be a quick operation.

`docker stop` operation times before and after this change:
```sh
$ time docker stop distracted_euler 
distracted_euler

real	0m10.325s
user	0m0.054s
sys	0m0.088s

$ time docker stop focused_zhukovsky 
focused_zhukovsky

real	0m0.339s
user	0m0.037s
sys	0m0.046s
```