### PR TITLE
Fix exposed Docker port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,6 @@ RUN \
 
 COPY ./ ./
 
-EXPOSE 10400
+EXPOSE 10200
 
 ENTRYPOINT ["bash", "docker_run.sh"]


### PR DESCRIPTION
The exposed port in the Dockerfile is incorrect.
Instead of `10200`, it was `10400`.