### PR TITLE
Rescan voices instead of freezing the list at startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 *
+!wyoming_piper/
 !wyoming_piper/*.py
 !wyoming_piper/voices.json
 !pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   `--data-dir`, not just `--download-dir` (where uploads still land). Missing
   dependencies and an unavailable port are reported at startup, before the
   backend loads its model.
+- Fix voices added or removed while the server runs being ignored until the
+  process restarted. The voice list was built once at startup, so a voice added
+  through the web UI was never advertised, and requesting it silently fell back
+  to the OmniVoice built-in speaker. Voices are now rescanned per `Describe` and
+  when an unknown voice is requested.
 - Fix custom voices being advertised under their `dataset` name instead of their
   file name, which made them impossible to synthesize when the two disagreed.
   The `dataset` name is still accepted as an alias, including as `--voice`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,11 @@ ARG EXTRAS="zeroconf,zh,web"
 WORKDIR /usr/src
 
 COPY ./pyproject.toml ./
+# The package has to exist for setuptools' packages.find to see it, or the
+# editable install maps nothing and importing wyoming_piper only works from
+# /usr/src. Just the __init__.py, so the install layer stays cached until the
+# version changes -- which changes pyproject.toml above anyway.
+COPY ./wyoming_piper/__init__.py ./wyoming_piper/
 RUN \
     apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ Then visit http://localhost:5000. The page has two sections:
   cloned voice's whole directory.
 
 Each section shows a warning when its backend is not the one the server was
-started with (via `--backend`), but the UI keeps working. Changes only take
-effect for the running server after you **reload the Piper integration or
-restart Home Assistant**, so the UI reminds you after every change.
+started with (via `--backend`), but the UI keeps working. The server picks up
+added and removed voices on its own — no restart — but Home Assistant caches the
+voice list, so **reload the Piper integration** for a new voice to appear in it.
 
 `--web-server-host` / `--web-server-port` set the bind address (default
 `127.0.0.1:5000`). The UI has no authentication and can upload and delete files

--- a/tests/test_custom_voices.py
+++ b/tests/test_custom_voices.py
@@ -45,7 +45,8 @@ def setup_result_fixture(data_dir: Path) -> "tuple[Any, Dict[str, Any]]":
         update_voices=False,
         no_streaming=False,
     )
-    return _setup_piper(args)
+    info_factory, voices_info = _setup_piper(args)
+    return info_factory(), voices_info
 
 
 def _resolve(voices_info: Dict[str, Any], name: str) -> str:
@@ -103,7 +104,7 @@ def test_dataset_name_accepted_as_default_voice(data_dir: Path) -> None:
         update_voices=False,
         no_streaming=False,
     )
-    _wyoming_info, voices_info = _setup_piper(args)
+    _info_factory, voices_info = _setup_piper(args)
 
     assert _resolve(voices_info, "jarvis-medium") == _MISMATCHED
 
@@ -122,7 +123,8 @@ def test_unusable_custom_voice_does_not_prevent_startup(data_dir: Path) -> None:
         update_voices=False,
         no_streaming=False,
     )
-    wyoming_info, _voices_info = _setup_piper(args)
+    info_factory, _voices_info = _setup_piper(args)
+    wyoming_info = info_factory()
 
     names = {v.name for v in wyoming_info.tts[0].voices}
     assert "orphan" not in names
@@ -145,6 +147,24 @@ def test_missing_default_voice_still_raises(data_dir: Path) -> None:
         _setup_piper(args)
 
 
+def test_voice_added_while_running_is_advertised(data_dir: Path) -> None:
+    """Describe reflects voices added after startup, without a restart."""
+    args = argparse.Namespace(
+        backend="piper",
+        voice=_MATCHED,
+        data_dir=[str(data_dir)],
+        download_dir=str(data_dir),
+        update_voices=False,
+        no_streaming=False,
+    )
+    info_factory, _voices_info = _setup_piper(args)
+    assert "added-later" not in {v.name for v in info_factory().tts[0].voices}
+
+    _write_voice(data_dir, "added-later", dataset="added-later")
+
+    assert "added-later" in {v.name for v in info_factory().tts[0].voices}
+
+
 def test_catalog_voice_not_shadowed_by_dataset_alias(data_dir: Path) -> None:
     """A "dataset" alias never overrides a real catalog voice."""
     _write_voice(data_dir, "my-copy-of-lessac", dataset="en_US-lessac-medium")
@@ -156,6 +176,6 @@ def test_catalog_voice_not_shadowed_by_dataset_alias(data_dir: Path) -> None:
         update_voices=False,
         no_streaming=False,
     )
-    _wyoming_info, voices_info = _setup_piper(args)
+    _info_factory, voices_info = _setup_piper(args)
 
     assert _resolve(voices_info, "en_US-lessac-medium") == "en_US-lessac-medium"

--- a/wyoming_piper/__main__.py
+++ b/wyoming_piper/__main__.py
@@ -6,14 +6,14 @@ import logging
 import signal
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict, List, Set
+from typing import Any, Callable, Dict, List, Set
 
 from wyoming.info import Attribution, Info, TtsProgram, TtsVoice, TtsVoiceSpeaker
 from wyoming.server import AsyncServer, AsyncTcpServer
 
 from . import __version__
 from .download import VoiceNotFoundError, ensure_voice_exists, find_voice, get_voices
-from .handler import PiperEventHandler, get_omnivoice_voices, load_omnivoice
+from .handler import PiperEventHandler, load_omnivoice, reload_omnivoice_voices
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -187,12 +187,12 @@ async def main() -> None:
             )
 
     if args.backend == "omnivoice":
-        wyoming_info, voices_info = _setup_omnivoice(args)
+        info_factory, voices_info = _setup_omnivoice(args)
     else:
         if not args.voice:
             parser.error("--voice is required for the piper backend")
 
-        wyoming_info, voices_info = _setup_piper(args)
+        info_factory, voices_info = _setup_piper(args)
 
     # Start server
     server = AsyncServer.from_uri(args.uri)
@@ -215,7 +215,7 @@ async def main() -> None:
         server.run(
             partial(
                 PiperEventHandler,
-                wyoming_info,
+                info_factory,
                 args,
                 voices_info,
             )
@@ -234,8 +234,15 @@ async def main() -> None:
 # -----------------------------------------------------------------------------
 
 
-def _setup_piper(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
-    """Build Wyoming info and voice table for the piper backend."""
+def _setup_piper(
+    args: argparse.Namespace,
+) -> "tuple[Callable[[], Info], Dict[str, Any]]":
+    """Load the voice table for the piper backend and ensure the default voice.
+
+    Returns a factory that rebuilds the Wyoming info, so custom voices added
+    while the server runs are advertised on the next Describe. Downloading (the
+    catalog, and the default voice) happens once, here.
+    """
     # Load voice info
     voices_info = get_voices(args.download_dir, update_voices=args.update_voices)
 
@@ -246,6 +253,23 @@ def _setup_piper(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
             aliases_info[voice_alias] = {"_is_alias": True, **voice_info}
 
     voices_info.update(aliases_info)
+
+    # Build once now so a broken --voice is reported at startup, and so any
+    # "dataset" alias the default voice needs is registered before it resolves.
+    _piper_info(args, voices_info)
+
+    # Ensure default voice is downloaded
+    voice_info = voices_info.get(args.voice, {})
+    voice_name = voice_info.get("key", args.voice)
+    assert voice_name is not None
+
+    ensure_voice_exists(voice_name, args.data_dir, args.download_dir, voices_info)
+
+    return partial(_piper_info, args, voices_info), voices_info
+
+
+def _piper_info(args: argparse.Namespace, voices_info: Dict[str, Any]) -> Info:
+    """Build Wyoming info from the catalog plus the custom voices on disk."""
     voices = [
         TtsVoice(
             name=voice_name,
@@ -296,7 +320,7 @@ def _setup_piper(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
         # above so that a "dataset" alias registered there can resolve it.
         _add_custom_voice(args.voice, args, voices_info, voices)
 
-    wyoming_info = Info(
+    return Info(
         tts=[
             TtsProgram(
                 name="piper",
@@ -311,15 +335,6 @@ def _setup_piper(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
             )
         ],
     )
-
-    # Ensure default voice is downloaded
-    voice_info = voices_info.get(args.voice, {})
-    voice_name = voice_info.get("key", args.voice)
-    assert voice_name is not None
-
-    ensure_voice_exists(voice_name, args.data_dir, args.download_dir, voices_info)
-
-    return wyoming_info, voices_info
 
 
 def _add_custom_voice(
@@ -393,11 +408,15 @@ def _add_custom_voice(
 # -----------------------------------------------------------------------------
 
 
-def _setup_omnivoice(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
-    """Build Wyoming info and ensure models for the omnivoice backend.
+def _setup_omnivoice(
+    args: argparse.Namespace,
+) -> "tuple[Callable[[], Info], Dict[str, Any]]":
+    """Ensure models for the omnivoice backend and return an info factory.
 
     The HuggingFace cache is pointed at ``--download-dir`` and the model is
-    downloaded there (unless ``--local-files-only`` is set).
+    downloaded there (unless ``--local-files-only`` is set). The returned factory
+    rescans ``--omnivoice-ref-dir`` on each call, so voices added while the
+    server runs are advertised on the next Describe.
     """
     import os
 
@@ -410,6 +429,12 @@ def _setup_omnivoice(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
     # before serving.
     load_omnivoice(args)
 
+    # voices_info is unused by the omnivoice backend.
+    return partial(_omnivoice_info, args), {}
+
+
+def _omnivoice_info(args: argparse.Namespace) -> Info:
+    """Build Wyoming info from the reference voices currently on disk."""
     from .omnivoice import (
         DEFAULT_VOICE_NAME,
         advertise_language,
@@ -430,8 +455,10 @@ def _setup_omnivoice(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
             languages=get_supported_languages(),
         )
     ]
-    # Cloning and voice-design (instruct) voices discovered under --omnivoice-ref-dir.
-    for ref in get_omnivoice_voices().values():
+    # Cloning and voice-design (instruct) voices under --omnivoice-ref-dir.
+    # Rescanned rather than reused from startup so a voice added since then --
+    # by the web UI, say -- is advertised without restarting the process.
+    for ref in reload_omnivoice_voices(args).values():
         lang = advertise_language(ref.language)
         voices.append(
             TtsVoice(
@@ -444,7 +471,7 @@ def _setup_omnivoice(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
             )
         )
 
-    wyoming_info = Info(
+    return Info(
         tts=[
             TtsProgram(
                 name="omnivoice",
@@ -457,9 +484,6 @@ def _setup_omnivoice(args: argparse.Namespace) -> "tuple[Info, Dict[str, Any]]":
             )
         ],
     )
-
-    # voices_info is unused by the omnivoice backend.
-    return wyoming_info, {}
 
 
 # -----------------------------------------------------------------------------

--- a/wyoming_piper/handler.py
+++ b/wyoming_piper/handler.py
@@ -6,7 +6,7 @@ import logging
 import math
 import tempfile
 import wave
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from piper import PiperVoice, SynthesisConfig
 from sentence_stream import SentenceBoundaryDetector
@@ -42,23 +42,39 @@ def get_omnivoice_voices() -> Dict[str, Any]:
     return _OMNIVOICE_VOICES
 
 
+def reload_omnivoice_voices(cli_args: argparse.Namespace) -> Dict[str, Any]:
+    """Rescan ``--omnivoice-ref-dir`` and return the voices now on disk.
+
+    Voices are added and removed while the server runs -- by the web UI, or by
+    hand -- so the reference directory is rescanned instead of being trusted
+    from startup. Scanning only walks directories and reads small text files.
+    """
+    global _OMNIVOICE_VOICES
+
+    if cli_args.omnivoice_ref_dir:
+        from .omnivoice import scan_ref_dir
+
+        _OMNIVOICE_VOICES = {
+            v.name: v for v in scan_ref_dir(cli_args.omnivoice_ref_dir)
+        }
+
+    return _OMNIVOICE_VOICES
+
+
 def load_omnivoice(cli_args: argparse.Namespace) -> None:
     """Load the shared OmniVoice model once (no-op if already loaded).
 
     Called at startup so the (heavy) model is ready before the first request;
     handlers share this single instance, serialized by ``_VOICE_LOCK``.
     """
-    global _OMNIVOICE, _OMNIVOICE_VOICES
+    global _OMNIVOICE
 
     if _OMNIVOICE is not None:
         return
 
-    from .omnivoice import OmniVoiceModel, ensure_omnivoice_downloaded, scan_ref_dir
+    from .omnivoice import OmniVoiceModel, ensure_omnivoice_downloaded
 
-    if cli_args.omnivoice_ref_dir:
-        _OMNIVOICE_VOICES = {
-            v.name: v for v in scan_ref_dir(cli_args.omnivoice_ref_dir)
-        }
+    reload_omnivoice_voices(cli_args)
 
     _LOGGER.info("Loading OmniVoice model")
     onnx_path = ensure_omnivoice_downloaded(
@@ -84,7 +100,7 @@ def _silence_bytes(wav_writer: wave.Wave_write, seconds: float) -> bytes:
 class PiperEventHandler(AsyncEventHandler):
     def __init__(
         self,
-        wyoming_info: Info,
+        info_factory: Callable[[], Info],
         cli_args: argparse.Namespace,
         voices_info: Dict[str, Any],
         *args,
@@ -93,7 +109,9 @@ class PiperEventHandler(AsyncEventHandler):
         super().__init__(*args, **kwargs)
 
         self.cli_args = cli_args
-        self.wyoming_info_event = wyoming_info.event()
+        # Called per Describe rather than captured once, so voices added while
+        # the server runs are advertised without restarting the process.
+        self.info_factory = info_factory
         self.voices_info = voices_info
         self.is_streaming: Optional[bool] = None
         self.sbd = SentenceBoundaryDetector()
@@ -101,7 +119,7 @@ class PiperEventHandler(AsyncEventHandler):
 
     async def handle_event(self, event: Event) -> bool:
         if Describe.is_type(event.type):
-            await self.write_event(self.wyoming_info_event)
+            await self.write_event(self.info_factory().event())
             _LOGGER.debug("Sent info")
             return True
 
@@ -378,8 +396,16 @@ class PiperEventHandler(AsyncEventHandler):
         if voice_name and voice_name != DEFAULT_VOICE_NAME:
             ref = _OMNIVOICE_VOICES.get(voice_name)
             if ref is None:
-                _LOGGER.debug(
-                    "Unknown OmniVoice voice %r; using built-in speaker", voice_name
+                # Added since the last scan? Look again before giving up, so a
+                # voice works as soon as it is created.
+                ref = reload_omnivoice_voices(self.cli_args).get(voice_name)
+
+            if ref is None:
+                # Warn, not debug: falling back to a different speaker is not
+                # something to discover only with debug logging on.
+                _LOGGER.warning(
+                    "Unknown OmniVoice voice %r; using the built-in speaker",
+                    voice_name,
                 )
 
         if ref is not None:

--- a/wyoming_piper/web_server.py
+++ b/wyoming_piper/web_server.py
@@ -35,10 +35,11 @@ from werkzeug.serving import make_server
 
 _LOGGER = logging.getLogger(__name__)
 
-# Reminder shown after any change so the user knows it is not live yet.
+# Shown after any change. The Wyoming server picks voices up on its own, but a
+# client caches the voice list from the last Describe, so it needs a nudge.
 RELOAD_MESSAGE = (
-    "Changes saved. Reload the Piper integration or restart Home Assistant "
-    "for them to take effect."
+    "Changes saved. Reload the Piper integration in Home Assistant to refresh "
+    "its voice list."
 )
 
 # Safe voice / language / directory names: no path separators, no surprises.


### PR DESCRIPTION
Adding a cloned voice through the web UI wrote `<ref-dir>/<lang>/<name>/` correctly, but then requesting `<name>` did not use it.

## Cause

The voice list was a snapshot of process start:

- `Info` is built once in `main()` and captured in the handler `partial`
- `_OMNIVOICE_VOICES` is filled once by `load_omnivoice()`

Reloading the Piper integration opens a new connection and a new handler — but serves that same frozen `Info`. It does not restart the wyoming-piper process, so the UI's "reload the Piper integration or restart Home Assistant" instruction could never have worked. Only restarting the add-on/container picked a new voice up.

Worse, the miss was silent: an unknown name fell through to the OmniVoice built-in speaker, logged at `debug`. You got audio, in the wrong voice.

Reproduced before the fix:

```
1. at startup, advertised: ['default']
2. upload ok: True | files: ['en_US/mike/ref.txt', 'en_US/mike/ref.wav']
3. after reload, Describe advertises: ['default']
4. synth lookup for 'mike': MISS -> silently uses built-in speaker
```

## Fix

`Info` is built per `Describe` through a factory rather than once, and `--omnivoice-ref-dir` is rescanned there and on an unknown voice name, so a voice works as soon as it is created. Scanning only walks directories and reads small text files.

The same staleness applied to custom **Piper** voices — unadvertised until restart, though those did synthesize, since that path resolves through `find_voice()` at request time. `_setup_piper()` returns a factory too, keeping the catalog load and the default-voice download as one-time startup work.

Same script after:

```
1. at startup, advertised: ['default']
2. upload ok: True
3. after reload, Describe advertises: ['default', 'mike']
4. synth lookup for 'mike': HIT -> /tmp/refs3/en_US/mike/ref.wav
5. after delete, advertised: ['default']
```

Also: the fallback to the built-in speaker is now logged at `warning` rather than `debug` — quietly substituting a different speaker should not require debug logging to notice — and the UI message and README no longer tell users to do something that could not have helped. The server now picks voices up on its own; reloading the integration is only needed because Home Assistant caches the voice list.

## Verification

19 tests pass (1 new, covering a voice added after startup being advertised); `black`/`isort`/`flake8`/`pylint`/`mypy` clean. The before/after sequences above were run against the real OmniVoice package in the built image.

Note the handler's first constructor argument changed from `Info` to `Callable[[], Info]`. Nothing else constructs `PiperEventHandler`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)